### PR TITLE
画像を中央に配置するかどうかのcheckboxを追加

### DIFF
--- a/typescript/simple-mercari-web/src/components/Listing/Listing.tsx
+++ b/typescript/simple-mercari-web/src/components/Listing/Listing.tsx
@@ -11,6 +11,7 @@ type formDataType = {
   name: string,
   category: string,
   image: string | File,
+  flag: string,
 }
 
 export const Listing: React.FC<Prop> = (props) => {
@@ -19,6 +20,7 @@ export const Listing: React.FC<Prop> = (props) => {
     name: "",
     category: "",
     image: "",
+    flag: "",
   };
   const [values, setValues] = useState<formDataType>(initialState);
 
@@ -36,12 +38,22 @@ export const Listing: React.FC<Prop> = (props) => {
       ...values, [event.target.name]: event.target.files![0],
     })
   };
+  const onFlagChange=()=>{
+    setValues({
+      ...values, flag: "true",
+    })
+  }
   const onSubmit = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault()
     const data = new FormData()
     data.append('name', values.name)
     data.append('category', values.category)
     data.append('image', values.image)
+    data.append('flag', values.flag)
+    console.log(data.get('name'));
+    console.log(data.get('category'));
+    console.log(data.get('image'));
+    console.log(data.get('flag'));
 
     fetch(server.concat('/items'), {
       method: 'POST',
@@ -81,6 +93,8 @@ export const Listing: React.FC<Prop> = (props) => {
             <br/>
             <input type='file' name='image' id='image' onChange={onFileChange} required />
           </div>
+          {/* <button onClick={onFlagChange}>中央に寄せる</button> */}
+          <input type='checkbox' onClick={onFlagChange}/> 画像を中央配置にされますか？
           <div className="text-center">
             <button type='submit' className="btn btn-danger">出品する</button>
           </div>

--- a/typescript/simple-mercari-web/src/components/Listing/Listing.tsx
+++ b/typescript/simple-mercari-web/src/components/Listing/Listing.tsx
@@ -20,7 +20,7 @@ export const Listing: React.FC<Prop> = (props) => {
     name: "",
     category: "",
     image: "",
-    flag: "",
+    flag: "false",
   };
   const [values, setValues] = useState<formDataType>(initialState);
 


### PR DESCRIPTION
## What
<!--- Write the change being made with this pull request --->
画像を中央寄せにするかどうかcheckboxを作成しました。
postするdataの中にflagというkeyを追加していて、flag="true"のとき、ユーザが中央寄せを希望している仕様になっています。
本当はbooleanのtureで送りたかったのですが、FormData()がbooleanに対応していなかったため、文字列型の"ture"を送信しています。
バックエンド側では、もしflag="true"の場合、中央寄せの画像データを、flag="false"の場合、そのままのデータを返していただきたいです。
また、booleanでないため、checkboxを二回以上押したとき、falseに戻らないなどの問題がある不完全な実装で、
またバックエンドの方が実装が大変だと思いますので、万が一うまくいったら使うくらいの気持ちでいていただけたら大丈夫です。
## Test
<!--- Write how to check pull request --->

## CHECKS :warning:

Please make sure you are aware of the following.

- [ ] **The changes in this PR doesn't have private information
